### PR TITLE
Added a binding for HBase 1.1, that works with secured HBase.

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -76,6 +76,7 @@ DATABASES = {
     "googledatastore" : "com.yahoo.ycsb.db.GoogleDatastoreClient",
     "hbase098"     : "com.yahoo.ycsb.db.HBaseClient",
     "hbase10"      : "com.yahoo.ycsb.db.HBaseClient10",
+    "hbase11"      : "com.yahoo.ycsb.db.HBaseClient11",
     "hbase12"      : "com.yahoo.ycsb.db.hbase12.HBaseClient12",
     "hbase14"      : "com.yahoo.ycsb.db.hbase14.HBaseClient14",
     "hbase20"      : "com.yahoo.ycsb.db.hbase20.HBaseClient20",

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -133,8 +133,8 @@ LICENSE file.
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter">
-	    	<property name="tokens" value="COMMA, SEMI"/>
-		</module>
+          <property name="tokens" value="COMMA, SEMI"/>
+        </module>
 
 
         <!-- Modifier Checks                                    -->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -39,6 +39,7 @@ LICENSE file.
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Interset Disabled
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>accumulo1.6-binding</artifactId>
@@ -69,11 +70,13 @@ LICENSE file.
       <artifactId>arangodb3-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
+    -->
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>asynchbase-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Interset Disabled
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>cassandra-binding</artifactId>
@@ -109,6 +112,7 @@ LICENSE file.
       <artifactId>dynamodb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
+    -->
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>elasticsearch-binding</artifactId>
@@ -119,6 +123,7 @@ LICENSE file.
       <artifactId>elasticsearch5-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Interset Disabled
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>geode-binding</artifactId>
@@ -134,6 +139,7 @@ LICENSE file.
       <artifactId>googlebigtable-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
+    -->
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>hbase098-binding</artifactId>
@@ -142,6 +148,11 @@ LICENSE file.
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>hbase10-binding</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.ycsb</groupId>
+      <artifactId>hbase11-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -159,6 +170,7 @@ LICENSE file.
       <artifactId>hbase20-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Interset Disabled
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>hypertable-binding</artifactId>
@@ -249,6 +261,7 @@ LICENSE file.
       <artifactId>tarantool-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
+    -->
 <!--
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>

--- a/hbase10/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
+++ b/hbase10/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
@@ -129,16 +129,27 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB {
       UserGroupInformation.setConfiguration(config);
     }
 
+    // START Changes by Interset
+    //System.out.println("HBase Config: " + config.toString());
+    //System.out.println("Properties: " + getProperties().toString());
+
     if ((getProperties().getProperty("principal")!=null)
         && (getProperties().getProperty("keytab")!=null)) {
       try {
-        UserGroupInformation.loginUserFromKeytab(getProperties().getProperty("principal"),
-              getProperties().getProperty("keytab"));
+        // Based off of Chen Yang's work here;
+        // https://community.hortonworks.com/articles/139167/measuring-hdp-performance-scale-and-reliability.html
+        UserGroupInformation ugi =
+            UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+                getProperties().getProperty("principal"),
+                getProperties().getProperty("keytab")
+            );
+        UserGroupInformation.setLoginUser(ugi);
       } catch (IOException e) {
         System.err.println("Keytab file is not readable or not found");
         throw new DBException(e);
       }
     }
+    // END Changes by Interset
 
     String table = getProperties().getProperty(TABLENAME_PROPERTY, TABLENAME_PROPERTY_DEFAULT);
     try {

--- a/hbase11/pom.xml
+++ b/hbase11/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.yahoo.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.15.0-SNAPSHOT</version>
+    <relativePath>../binding-parent/</relativePath>
+  </parent>
+
+  <artifactId>hbase11-binding</artifactId>
+  <name>HBase 1.1.2 DB Binding</name>
+
+  <properties>
+    <!-- Tests do not run on jdk9 -->
+    <skipJDK9Tests>true</skipJDK9Tests>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.yahoo.ycsb</groupId>
+      <artifactId>hbase10-binding</artifactId>
+      <version>${project.version}</version>
+      <!-- Should match all compile scoped dependencies -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase11.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-testing-util</artifactId>
+      <version>${hbase11.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/hbase11/src/main/java/com/yahoo/ycsb/db/HBaseClient11.java
+++ b/hbase11/src/main/java/com/yahoo/ycsb/db/HBaseClient11.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.yahoo.ycsb.db;
+
+/**
+ * HBase 1.1.2 client for YCSB framework.
+ *
+ * A modified version of HBaseClient (which targets HBase v1.1.2).
+ *
+ * It should run equivalent to following the hbase098 binding README.
+ *
+ */
+public class HBaseClient11 extends HBaseClient10 {
+}

--- a/hbase11/src/main/java/com/yahoo/ycsb/db/package-info.java
+++ b/hbase11/src/main/java/com/yahoo/ycsb/db/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for <a href="https://hbase.apache.org/">HBase</a> 
+ * using the HBase 1.1.2 API.
+ */
+package com.yahoo.ycsb.db;
+

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@ LICENSE file.
     <googlebigtable.version>1.3.0</googlebigtable.version>
     <hbase098.version>0.98.14-hadoop2</hbase098.version>
     <hbase10.version>1.0.2</hbase10.version>
+    <hbase11.version>1.1.2</hbase11.version>
     <hbase12.version>1.2.5</hbase12.version>
     <hbase14.version>1.4.2</hbase14.version>
     <hbase20.version>2.0.0</hbase20.version>
@@ -113,13 +114,16 @@ LICENSE file.
     <module>binding-parent</module>
     <module>distribution</module>
     <!-- all the datastore bindings, lex sorted please -->
+    <!-- Interset Disabled
     <module>accumulo1.6</module>
     <module>accumulo1.7</module>
     <module>accumulo1.8</module>
     <module>aerospike</module>
     <module>arangodb</module>
     <module>arangodb3</module>
+    -->
     <module>asynchbase</module>
+    <!-- Interset Disabled
     <module>azuredocumentdb</module>
     <module>azuretablestorage</module>
     <module>cassandra</module>
@@ -127,21 +131,28 @@ LICENSE file.
     <module>couchbase</module>
     <module>couchbase2</module>
     <module>dynamodb</module>
+    -->
     <module>elasticsearch</module>
     <module>elasticsearch5</module>
+    <!-- Interset Disabled
     <module>geode</module>
     <module>googlebigtable</module>
     <module>googledatastore</module>
+    -->
     <module>hbase098</module>
     <module>hbase10</module>
+    <module>hbase11</module>
     <module>hbase12</module>
     <module>hbase14</module>
     <module>hbase20</module>
+    <!-- Interset Disabled
     <module>hypertable</module>
     <module>infinispan</module>
     <module>jdbc</module>
     <module>kudu</module>
+    -->
     <!--<module>mapkeeper</module>-->
+    <!-- Interset Disabled
     <module>maprdb</module>
     <module>maprjsondb</module>
     <module>memcached</module>
@@ -156,6 +167,7 @@ LICENSE file.
     <module>solr</module>
     <module>solr6</module>
     <module>tarantool</module>
+    -->
     <!--<module>voldemort</module>-->
   </modules>
 


### PR DESCRIPTION
- Made slight changes to HBase 1.0 implementation, based on Chen Yang's article; https://community.hortonworks.com/articles/139167/measuring-hdp-performance-scale-and-reliability.html
  - All that was really needed it seems, was calling `UserGroupInformation.setLoginUser(...)`
- Added an HBase 1.1(.2) implementation properly, that uses an HBase 1.1.2 client.
- Disabled any binding not relevant to Interset
  - Reduced local build time from 1m30s to 30s, and resulting tar.gz from ~650MB to ~250MB